### PR TITLE
Unify GCP ADC bootstrap: ensure_adc() + /health with google.auth.defa…

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,11 +2,18 @@
 from dotenv import load_dotenv
 import pathlib
 import os
+import google.auth
 
-import app.services.google_adc_bootstrap  # ← 追加行：これでADCを自動ブートストラップ
+# ✅ 追加：関数として import
+from app.services.google_adc_bootstrap import ensure_adc
+
+#import app.services.google_adc_bootstrap  # ← 追加行：これでADCを自動ブートストラップ
 # backend/.env を明示的に読み込む
 env_path = pathlib.Path(__file__).resolve().parent.parent / ".env"
 load_dotenv(dotenv_path=env_path)
+
+# ✅ 追加：.env を読んだ“後”に ADC を確定（GCP_SA_JSON_B64 / GCP_SA_JSON / 既存の GAC を優先順でセット）
+ensure_adc()
 
 # .env の変数を取得
 cred_path_raw = os.getenv("GOOGLE_APPLICATION_CREDENTIALS")
@@ -82,7 +89,15 @@ app.include_router(user_login_api.router)
 # ヘルスチェック
 @app.get("/health")
 def health():
-    return {"status": "ok"}
+    try:
+        creds, project = google.auth.default()  # ← ADC を実際に取得
+        return {
+            "status": "ok",
+            "project": project,
+            "cred": os.getenv("GOOGLE_APPLICATION_CREDENTIALS")
+        }
+    except Exception as e:
+        return {"status": "error", "detail": str(e)}
 
 # ★ 起動時：同期DBの create_all を1回実行（await しない）
 @app.on_event("startup")

--- a/backend/app/services/google_adc_bootstrap.py
+++ b/backend/app/services/google_adc_bootstrap.py
@@ -3,30 +3,32 @@
 環境変数に格納したサービスアカウントJSONを、起動時に"鍵ファイル"として書き出し、
 GOOGLE_APPLICATION_CREDENTIALS にそのパスを設定するブートストラップ。
 
-これにより、既存コード（ファイルパス前提のADC）がそのまま動作する。
-- 参照する環境変数の優先順:
-    1) GCP_SA_JSON_B64  : Base64エンコード済みのJSON本文
-    2) GCP_SA_JSON      : プレーンなJSON本文
-    3) 何も無ければ何もしない（既に GOOGLE_APPLICATION_CREDENTIALS が設定されている想定）
+優先順:
+  1) GCP_SA_JSON_B64 / GOOGLE_APPLICATION_CREDENTIALS_JSON_B64  (Base64)
+  2) GCP_SA_JSON     / GOOGLE_APPLICATION_CREDENTIALS_JSON      (プレーンJSON)
+  3) 何も無ければ何もしない（既存 GOOGLE_APPLICATION_CREDENTIALS を尊重）
 
-書き出し先は、書き込み可能な順に試行:
-    - /home/site/wwwroot/secrets/gcp-sa.json   (App Service Linuxで一般的)
-    - OSの一時ディレクトリ
+書き出し先は書き込み可能な場所を自動選択:
+  - /home/site/wwwroot/secrets/gcp-sa.json  (Azure Linux App Serviceで一般的)
+  - OSの一時ディレクトリ (tempfile.gettempdir())
 """
 
+from __future__ import annotations
 import os
 import base64
 import json
 import tempfile
+import pathlib
+from typing import Optional, Tuple
 
-BOOTSTRAP_FLAG = "_GCP_ADC_BOOTSTRAPPED"
+_BOOTSTRAP_FLAG = "_GCP_ADC_BOOTSTRAPPED"
 
-def _ensure_dir(p: str) -> None:
-    d = os.path.dirname(p)
-    if not os.path.exists(d):
-        os.makedirs(d, exist_ok=True)
 
-def _writable(path: str) -> bool:
+def _ensure_dir(path: str) -> None:
+    pathlib.Path(path).parent.mkdir(parents=True, exist_ok=True)
+
+
+def _is_writable(path: str) -> bool:
     try:
         _ensure_dir(path)
         with open(path, "a"):
@@ -35,60 +37,86 @@ def _writable(path: str) -> bool:
     except Exception:
         return False
 
+
 def _pick_target_path() -> str:
     # App Service でよく使う配置先
     candidate1 = "/home/site/wwwroot/secrets/gcp-sa.json"
-    if _writable(candidate1):
+    if _is_writable(candidate1):
         return candidate1
-    # だめなら一時フォルダ
-    tmp = os.path.join(tempfile.gettempdir(), "gcp-sa.json")
-    _ensure_dir(tmp)
-    return tmp
+    # ダメなら一時フォルダ
+    tmp = pathlib.Path(tempfile.gettempdir()) / "gcp-sa.json"
+    _ensure_dir(str(tmp))
+    return str(tmp)
 
-def _load_json_from_env() -> str | None:
-    b64 = os.environ.get("GCP_SA_JSON_B64") or os.environ.get("GOOGLE_APPLICATION_CREDENTIALS_JSON_B64")
-    raw = os.environ.get("GCP_SA_JSON") or os.environ.get("GOOGLE_APPLICATION_CREDENTIALS_JSON")
-    if b64:
-        try:
-            return base64.b64decode(b64).decode("utf-8")
-        except Exception:
-            # フォールバックでそのまま返す（誤ってプレーンを入れた場合でも動かす）
-            return b64
-    if raw:
-        return raw
-    return None
+
+def _load_from_env() -> Tuple[Optional[str], Optional[str]]:
+    """環境変数からJSON本文を取得して返す (content, source_key)。見つからなければ (None, None)。"""
+    # Base64 優先
+    for key in ("GCP_SA_JSON_B64", "GOOGLE_APPLICATION_CREDENTIALS_JSON_B64"):
+        val = os.getenv(key)
+        if val:
+            try:
+                decoded = base64.b64decode(val).decode("utf-8", errors="strict")
+                return decoded, key
+            except Exception:
+                # 誤ってプレーンを入れた場合などは、そのまま扱う
+                return val, key
+
+    # プレーンJSON
+    for key in ("GCP_SA_JSON", "GOOGLE_APPLICATION_CREDENTIALS_JSON"):
+        val = os.getenv(key)
+        if val:
+            return val, key
+
+    return None, None
+
 
 def _write_json_file(content: str, path: str) -> str:
-    with open(path, "w", encoding="utf-8") as f:
-        # JSONの妥当性チェックついでに整形してから書く
+    """できるだけJSONとして整形して書く。無理なら生文字列のまま書く。"""
+    _ensure_dir(path)
+    try:
+        # 文字列だがJSONとして正規化できる場合
         obj = json.loads(content)
-        json.dump(obj, f, ensure_ascii=False)
-        f.write("\n")
-    # パーミッション（可能なら）を絞る
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(obj, f, ensure_ascii=False)
+            f.write("\n")
+    except Exception:
+        # JSONとして解釈できなければ、そのまま書く（貼り付け時のエスケープ崩れ救済）
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(content if isinstance(content, str) else str(content))
+            f.write("\n")
+
+    # パーミッションは可能なら600へ
     try:
         os.chmod(path, 0o600)
     except Exception:
         pass
+
     return path
 
-def bootstrap() -> None:
-    # 多重実行防止
-    if os.environ.get(BOOTSTRAP_FLAG) == "1":
-        return
-    os.environ[BOOTSTRAP_FLAG] = "1"
 
-    # 既にファイルパスが設定されているなら何もしない
-    if os.environ.get("GOOGLE_APPLICATION_CREDENTIALS"):
+def ensure_adc() -> None:
+    """環境変数から鍵を復元して GAC を設定。既に設定済みなら何もしない。"""
+    # 再入防止
+    if os.environ.get(_BOOTSTRAP_FLAG) == "1":
+        return
+    os.environ[_BOOTSTRAP_FLAG] = "1"
+
+    # 既に GOOGLE_APPLICATION_CREDENTIALS があれば尊重（ローカルのファイル指定等）
+    gac = os.getenv("GOOGLE_APPLICATION_CREDENTIALS")
+    if gac:
         return
 
-    content = _load_json_from_env()
+    content, _source = _load_from_env()
     if not content:
-        # 何もなければ黙って終了（ローカル等で従来のファイル方式を使っている想定）
+        # 何も無ければ、OSや他の仕組みで設定されている想定
         return
 
     target = _pick_target_path()
     path = _write_json_file(content, target)
     os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = path
 
-# 即時実行（インポートした瞬間に有効化）
-bootstrap()
+
+# 互換API（以前の bootstrap() 呼び出しに対応）
+def bootstrap() -> None:
+    ensure_adc()


### PR DESCRIPTION
### 概要
- GCP サービスアカウント認証 (ADC) のブートストラップ処理を整理しました。
- ローカル（.env にファイルパスを記載）と Azure（環境変数に JSON を直接格納）の両方で同じコードが動作します。

### 変更点
- `app/services/google_adc_bootstrap.py`
  - `ensure_adc()` を追加し、Base64/プレーン JSON 両対応
  - 書き込み先は `/home/site/wwwroot/secrets/` または tempdir に自動決定
  - 再入防止のフラグを追加
- `app/main.py`
  - `.env` 読込直後に `ensure_adc()` を呼び出すよう修正
  - `/health` エンドポイントで `google.auth.default()` を確認できるように

### 動作確認
- ローカル：.env に `GOOGLE_APPLICATION_CREDENTIALS=xxx.json` を設定し `/health` が OK になることを確認
- Azure：App Settings に `GCP_SA_JSON` を設定し `/health` が OK になることを確認
